### PR TITLE
Integer keys

### DIFF
--- a/Tests/MessagePackerTests/MapPackedTests.swift
+++ b/Tests/MessagePackerTests/MapPackedTests.swift
@@ -44,6 +44,26 @@ class MapPackedTests: XCTestCase {
         XCTAssertEqual((try encoder.encode(input)).count, output)
     }
 
+    func testMapAllowIntKey() {
+        let input = [8: 1.1]
+        let output = Data([129, 8, 203, 63, 241, 153, 153, 153, 153, 153, 154])
+        let encoder = MessagePackEncoder(allowIntKeys: true)
+        XCTAssertEqual(try encoder.encode(input), output)
+    }
+
+    func testMapAllowIntKeyWithString() {
+        let input = ["A": 9]
+        let output = Data([129, 161, 65, 9])
+        let encoder = MessagePackEncoder(allowIntKeys: true)
+        XCTAssertEqual(try encoder.encode(input), output)
+    }
+
+    func testMapAllowIntKeyWithIntegerInString() {
+        let input = ["1": 9]
+        let output = Data([129, 1, 9])
+        let encoder = MessagePackEncoder(allowIntKeys: true)
+        XCTAssertEqual(try encoder.encode(input), output)
+    }
 
     func test2DimensionalMap() {
         let input = ["a": ["b": 2]]
@@ -51,3 +71,5 @@ class MapPackedTests: XCTestCase {
         XCTAssertEqual(try encoder.encode(input), output)
     }
 }
+
+

--- a/Tests/MessagePackerTests/MapUnpackedTests.swift
+++ b/Tests/MessagePackerTests/MapUnpackedTests.swift
@@ -39,6 +39,32 @@ class MapUnpackedTests: XCTestCase {
         }
     }
 
+    func testAllowIntKey() {
+        let input = Data([130, 2, 203, 64, 1, 153, 153, 153, 153, 153, 154, 1, 203, 63, 241, 153, 153, 153, 153, 153, 154])
+        let output: [Int: Double] = [1: 1.1, 2: 2.2]
+
+        do {
+            let decoder = MessagePackDecoder(allowIntKeys: true)
+            let result: [Int: Double] = try decoder.decode(Dictionary.self, from: input)
+            result.forEach { XCTAssertEqual(output[$0.key], $0.value) }
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testAllowIntKeyWithString() {
+        let input = Data([130, 161, 65, 9, 1, 9])
+        let output: [String: Int] = ["1": 9, "A": 9]
+
+        do {
+            let decoder = MessagePackDecoder(allowIntKeys: true)
+            let result: [String: Int] = try decoder.decode(Dictionary.self, from: input)
+            result.forEach { XCTAssertEqual(output[$0.key], $0.value) }
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
     func test2DimensionalMap() {
         let input = Data([129, 161, 97, 129, 161, 98, 2])
         let output = ["a": ["b": 2]]
@@ -46,3 +72,4 @@ class MapUnpackedTests: XCTestCase {
         XCTAssertEqual(try decoder.decode(Dictionary.self, from: input), output)
     }
 }
+


### PR DESCRIPTION
This code adds an encoding and decoding mode where keys in the message pack data are allowed to be integer. If the provided key returns a non-`nil` `intValue` and `allowIntKeys` is set to `true` in the encoder/decoder, the integer key will be used instead of its string form.