### PR TITLE
fix decoding empty Data() [196, 0] and add test coverage

### DIFF
--- a/Sources/Extensions/Data+.swift
+++ b/Sources/Extensions/Data+.swift
@@ -27,7 +27,7 @@ extension Data {
         let start = startIndex + range.lowerBound
         let end = startIndex + range.upperBound
 
-        guard start < endIndex && end <= endIndex else { throw MessagePackError.outOfRange }
+        guard start <= endIndex && end <= endIndex else { throw MessagePackError.outOfRange }
 
         return self[start..<end]
     }

--- a/Tests/MessagePackerTests/BinaryUnpackedTests.swift
+++ b/Tests/MessagePackerTests/BinaryUnpackedTests.swift
@@ -25,4 +25,10 @@ class BinaryUnpackedTests: XCTestCase {
         let output = Data([0, 1, 2, 3, 4])
         XCTAssertEqual(try decoder.decode(Data.self, from: input), output)
     }
+
+    func testEmpty() {
+        let input = Data([196, 0])
+        let output = Data()
+        XCTAssertEqual(try decoder.decode(Data.self, from: input), output)
+    }
 }


### PR DESCRIPTION
See https://github.com/hirotakan/MessagePacker/issues/38