### PR TITLE
Fix 64-bit integer decoding on 32-bit devices

### DIFF
--- a/Sources/MessagePackDecoder.swift
+++ b/Sources/MessagePackDecoder.swift
@@ -99,7 +99,7 @@ private extension MessagePackDecoder {
     func unboxInteger<T: BinaryInteger & MessagePackable>(_ value: Data, as type: T.Type) throws -> T where T.T == T {
         if let firstByte = value.first,
             let _ = try? MessagePackType.UnsignedIntegerType(firstByte) {
-            return T(try unboxMessagePack(value, as: UInt.self))
+            return T(try unboxMessagePack(value, as: UInt64.self))
         } else {
             return try unboxMessagePack(value, as: type)
         }


### PR DESCRIPTION
### Bug Description

Crash when decoding 64-bit integer on 32-bit devices like Apple Watch arm64_32 devices (not simulator, its is x86_64 on Intel Mac or arm64 on Apple Silicon Mac).

Error message: `Fatal error: Not enough bits to represent the passed value`

### Why am I doing this?

I want to decode 64-bit integer correctly on 32-bit devices.

ref. The following is the list of devices that have Int/UInt of 32-bits:

- (armv7s: iPhone 5, iPhone 5c)
- armv7k: Apple Watch, Edition, Series 2, 3
- arm64_32: **Apple Watch Series 4, 5, SE, 6, 7**

### Solution Description

Unbox integer as `UInt64`.
