### PR TITLE
Mark `MessagePackTimestamp` and `MessagePackExtension` as `Sendable`

### DIFF
--- a/Sources/MessagePackExtension.swift
+++ b/Sources/MessagePackExtension.swift
@@ -52,3 +52,8 @@ extension MessagePackExtension: MessagePackable {
         return try MessagePackType.ExtensionType.unpack(for: value)
     }
 }
+
+#if swift(>=5.7)
+extension MessagePackExtension: Sendable {
+}
+#endif

--- a/Sources/MessagePackTimestamp.swift
+++ b/Sources/MessagePackTimestamp.swift
@@ -67,3 +67,8 @@ extension MessagePackTimestamp: MessagePackable {
         return try MessagePackTimestamp(extension: ext)
     }
 }
+
+#if swift(>=5.7)
+extension MessagePackTimestamp: Sendable {
+}
+#endif


### PR DESCRIPTION
`MessagePackTimestamp` and `MessagePackExtension` can be marked [`Sendable`](https://developer.apple.com/documentation/swift/sendable) (a.k.a. thread-safe) because they are value types. Marking a type as `Sendable` will allow values of that type to be passed across concurrency domains.