### PR TITLE
Support encoding/decoding `MessagePackTimestamp` using non-MessagePack encoders/decoders

### DIFF
--- a/Sources/Extensions/SingleValueDecodingContainer+.swift
+++ b/Sources/Extensions/SingleValueDecodingContainer+.swift
@@ -8,8 +8,15 @@
 
 import Foundation
 
+enum MessagePackableDecodingError: Error {
+    case notMessagePackDecoder
+}
+
 extension SingleValueDecodingContainer {
     func decode<T: MessagePackable>(as type: T.Type) throws -> T where T.T == T {
-        return try (self as! MessagePackDecoder.SingleValueContainer).decode(as: type)
+        guard let messagePackContainer = self as? MessagePackDecoder.SingleValueContainer else {
+            throw MessagePackableDecodingError.notMessagePackDecoder
+        }
+        return try messagePackContainer.decode(as: type)
     }
 }

--- a/Sources/Extensions/SingleValueEncodingContainer+.swift
+++ b/Sources/Extensions/SingleValueEncodingContainer+.swift
@@ -8,8 +8,15 @@
 
 import Foundation
 
+enum MessagePackableEncodingError: Error {
+    case notMessagePackEncoder
+}
+
 extension SingleValueEncodingContainer {
     func encode<T: MessagePackable>(_ value: T) throws {
-        try (self as! MessagePackEncoder.SingleValueContainer).encode(from: value)
+        guard let messagePackContainer = self as? MessagePackEncoder.SingleValueContainer else {
+            throw MessagePackableEncodingError.notMessagePackEncoder
+        }
+        try messagePackContainer.encode(from: value)
     }
 }

--- a/Tests/MessagePackerTests/TimestampPackedTests.swift
+++ b/Tests/MessagePackerTests/TimestampPackedTests.swift
@@ -37,4 +37,19 @@ class TimestampPackedTests: XCTestCase {
         let output = Data([199, 12, 255, 25, 69, 229, 222, 0, 0, 0, 14, 211, 132, 20, 74])
         XCTAssertEqual(try encoder.encode(input), output)
     }
+
+    func testSupportsNonMessagePackEncoder() {
+        let input = MessagePackTimestamp(seconds: 1542592042, nanoseconds: 209741115)
+
+        let jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        let output = """
+            {
+              "nanoseconds" : 209741115,
+              "seconds" : 1542592042
+            }
+            """.data(using: .utf8)!
+        XCTAssertEqual(try jsonEncoder.encode(input), output)
+    }
 }

--- a/Tests/MessagePackerTests/TimestampUnpackedTests.swift
+++ b/Tests/MessagePackerTests/TimestampUnpackedTests.swift
@@ -69,4 +69,18 @@ class TimestampUnpackedTests: XCTestCase {
 
         XCTAssertEqual(try decoder.decode(Vehicle.self, from: input), output)
     }
+
+    func testSupportsNonMessagePackDecoder() {
+        let input = """
+            {
+              "nanoseconds" : 209741115,
+              "seconds" : 1542592042
+            }
+            """.data(using: .utf8)!
+
+        let jsonDecoder = JSONDecoder()
+
+        let output = MessagePackTimestamp(seconds: 1542592042, nanoseconds: 209741115)
+        XCTAssertEqual(try jsonDecoder.decode(MessagePackTimestamp.self, from: input), output)
+    }
 }


### PR DESCRIPTION
`MessagePackTimestamp` currently requires a `MessagePackEncoder`/`MessagePackDecoder` for encoding/decoding. Using a non-MessagePack encoder/decoder results in a fatal error.

A client may want to use a human-readable serialization format, such as JSON, in automated tests to make it easier to read and write the test. However, if a `MessagePackTimestamp` is present anywhere in the data structure to be serialized/deserialized, the test will crash.

To enable the above use case, we add fallback behavior for non-MessagePack encoders/decoders when encoding/decoding `MessagePackTimestamp`.