### PR TITLE
Verify the first byte when decoding `Double`/`Float`

### DIFF
--- a/Sources/MessagePackTypes/MessagePackType+DoubleType.swift
+++ b/Sources/MessagePackTypes/MessagePackType+DoubleType.swift
@@ -32,6 +32,9 @@ extension MessagePackType.DoubleType {
     }
 
     static func unpack(for value: Data) throws -> Double {
+        guard let firstByte = value.first else { throw MessagePackError.emptyData }
+        guard firstByte == self.firstByte else { throw MessagePackError.invalidData }
+
         let unpacked: UInt64 = try unpackInteger(try value.subdata(dataRange))
         return Double(bitPattern: UInt64(bigEndian: unpacked))
     }

--- a/Sources/MessagePackTypes/MessagePackType+FloatType.swift
+++ b/Sources/MessagePackTypes/MessagePackType+FloatType.swift
@@ -32,6 +32,9 @@ extension MessagePackType.FloatType {
     }
 
     static func unpack(for value: Data) throws -> Float {
+        guard let firstByte = value.first else { throw MessagePackError.emptyData }
+        guard firstByte == self.firstByte else { throw MessagePackError.invalidData }
+
         let unpacked: UInt32 = try unpackInteger(try value.subdata(dataRange))
         return Float(bitPattern: UInt32(bigEndian: unpacked))
     }

--- a/Tests/MessagePackerTests/DoubleUnpackedTests.swift
+++ b/Tests/MessagePackerTests/DoubleUnpackedTests.swift
@@ -25,4 +25,9 @@ class DoubleUnpackedTests: XCTestCase {
         let output = 3.14
         XCTAssertEqual(try decoder.decode(Double.self, from: input), output)
     }
+
+    func testMismatchedType() {
+        let input = Data([207, 255, 255, 255, 255, 255, 255, 255, 255])
+        XCTAssertThrowsError(try decoder.decode(Double.self, from: input))
+    }
 }

--- a/Tests/MessagePackerTests/FloatUnpackedTests.swift
+++ b/Tests/MessagePackerTests/FloatUnpackedTests.swift
@@ -25,4 +25,9 @@ class FloatUnpackedTests: XCTestCase {
         let output: Float = 3.14
         XCTAssertEqual(try decoder.decode(Float.self, from: input), output)
     }
+
+   func testMismatchedType() {
+       let input = Data([207, 255, 255, 255, 255, 255, 255, 255, 255])
+       XCTAssertThrowsError(try decoder.decode(Float.self, from: input))
+   }
 }


### PR DESCRIPTION
Currently, the decoding code for `Double`/`Float` parses the data without first verifying that the data represents a `Double`/`Float`. This is unsafe. For example, a value of type `UInt64` could be decoded as a `Double` with the same bit pattern (but not the same semantic value).

Instead, the decoding code should always check the first byte before continuing to parse the data.