### PR TITLE
chore: update target versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   xcode:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     strategy:
       matrix:
-        xcode: [10.3, 11.6]
+        xcode: [10.3, 11.6, 14.2]
       fail-fast: false
     name: Xcode ${{ matrix.xcode }}
     env:
@@ -26,7 +26,7 @@ jobs:
           xcodebuild build -scheme "MessagePacker" -destination "name=Apple Watch Series 4 - 44mm" -configuration Release ENABLE_TESTABILITY=YES | xcpretty
 
   swiftpm:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     name: SwiftPM
     env:
       DEVELOPER_DIR: "/Applications/Xcode_11.6.app"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/MessagePacker.podspec
+++ b/MessagePacker.podspec
@@ -13,10 +13,10 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/hirotakan/MessagePacker"
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author       = "hirotakan"
-  s.ios.deployment_target = "8.0"
-  s.osx.deployment_target = "10.10"
-  s.watchos.deployment_target = "2.0"
-  s.tvos.deployment_target = "9.0"
+  s.ios.deployment_target = "11.0"
+  s.osx.deployment_target = "13.0"
+  s.watchos.deployment_target = "9.0"
+  s.tvos.deployment_target = "16.0"
 
   s.swift_version  = "5.0"
   s.source       = { :git => "https://github.com/hirotakan/MessagePacker.git", :tag => "#{s.version}" }

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(
     name: "MessagePacker",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+        .macOS(.v13), .iOS(.v11), .tvOS(.v16), .watchOS(.v9)
     ],
     products: [
         .library(name: "MessagePacker", targets: ["MessagePacker"]),


### PR DESCRIPTION
this PR aims to update the target versions of this package. The reason of this is that today I tried to run a package that depends on this using xcode 14.3 and it fails because iOS 8 is not supported anymore (more info: https://developer.apple.com/forums/thread/728021)

closes #48 